### PR TITLE
Add SaaSCity to launchdb-fallback.json

### DIFF
--- a/public/launchdb-fallback.json
+++ b/public/launchdb-fallback.json
@@ -952,5 +952,11 @@
     "name": "Open Source Projects",
     "description": "A categorized directory where makers submit and discover open-source projects and alternatives to proprietary software.",
     "submission_link": "https://opensourceprojects.cc/submit"
+  },
+  {
+    "id": 160,
+    "name": "SaaSCity",
+    "description": "A gamified SaaS directory where each submitted product becomes a building on an interactive isometric city map.",
+    "submission_link": "https://saascity.io/submit"
   }
 ]


### PR DESCRIPTION
Adds **SaaSCity** as entry 160 in `public/launchdb-fallback.json`, keeping it in sync with the main list.

```json
{
  "id": 160,
  "name": "SaaSCity",
  "description": "A gamified SaaS directory where each submitted product becomes a building on an interactive isometric city map.",
  "submission_link": "https://saascity.io/submit"
}
```

Companion to theshubh77/awesome-saas-directories#62, which adds the same entry to the README table — this keeps the fallback data consistent with it.

- Ahrefs DR 46
- Free listing with an indexed product page; paid tiers add a dofollow backlink and map placement
- Every submission manually reviewed, usually approved within 24h